### PR TITLE
Allow partial updates to be passed in to Model#update

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ LevelModel.prototype.update = function (key, data, callback) {
     if (self.timestamps) model.updated = self.timestamp()
     model = self.beforeUpdate(model)
 
-    var validated = self.validate(data)
+    var validated = self.validate(model)
     if (!validated) return callback(new Error(JSON.stringify(self.validate.errors)))
 
     self.indexer.updateIndexes(model, function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -78,6 +78,23 @@ test('update a model', function (t) {
   })
 })
 
+test('update a model with partial data', function (t) {
+  var data = {
+    test: 'another instance!',
+    ok: 5
+  }
+
+  example.create(data, function (err, instance) {
+    t.notOk(err)
+
+    example.update(instance.key, {ok: 6}, function (err, updated) {
+      t.notOk(err)
+      t.equal(updated.ok, 6)
+      t.end()
+    })
+  })
+})
+
 test('reject model creation if it doesnt fit the schema', function (t) {
   var data = {
     test: 'huh',
@@ -100,7 +117,7 @@ test('list models', function (t) {
   }
 
   function end () {
-    t.equals(count, 3)
+    t.equals(count, 4)
     t.end()
   }
 


### PR DESCRIPTION
This is a breaking change, but I think it's a more usable API. The only code change is to validate the updated model within Model#update instead of validating the passed in data.

Thoughts?